### PR TITLE
Add simple map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ $ gem install pbbuilder
 ```
 
 ## Contributing
-Contribution directions go here.
+
+When debugging, make sure you're prepending `::Kernel` to any calls such as `puts` as otherwise the code will think you're trying to add another attribute onto the protobuf.
 
 ## License
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -58,9 +58,9 @@ class Pbbuilder < BasicObject
     elsif args.length == 1
       arg = args.first
       if descriptor.label == :repeated
-        if arg.kind_of?(::Hash)
+        if arg.respond_to?(:to_hash)
           # pb.fields {"one" => "two"}
-          arg.to_h.each do |k, v|
+          arg.to_hash.each do |k, v|
             @message[name][k] = v
           end
         elsif arg.respond_to?(:to_ary)

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -58,7 +58,12 @@ class Pbbuilder < BasicObject
     elsif args.length == 1
       arg = args.first
       if descriptor.label == :repeated
-        if arg.respond_to?(:to_ary)
+        if arg.kind_of?(::Hash)
+          # pb.fields {"one" => "two"}
+          arg.to_h.each do |k, v|
+            @message[name][k] = v
+          end
+        elsif arg.respond_to?(:to_ary)
           # pb.fields ["one", "two"]
           # Using concat so it behaves the same as _append_repeated
           @message[name].concat arg.to_ary

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = "pbbuilder"
-  spec.version = "0.5.0"
+  spec.version = "0.6.0"
   spec.authors = ["Bouke van der Bijl"]
   spec.email = ["bouke@cheddar.me"]
   spec.homepage = "https://github.com/cheddar-me/pbbuilder"

--- a/test/pbbuilder_test.rb
+++ b/test/pbbuilder_test.rb
@@ -14,11 +14,18 @@ class PbbuilderTest < ActiveSupport::TestCase
         pb.paths ["ok", "that's"]
         pb.paths "cool"
       end
+      pb.favourite_foods({
+        "Breakfast" => "Eggs",
+        "Lunch" => "Shawarma",
+        "Dinner" => "Pizza"
+      })
     end.target!
+
     assert_equal "Hello world", person.name
     assert_equal "Friend #1", person.friends.first.name
     assert_equal ["ok", "that's", "cool"], person.field_mask.paths
     assert_equal "Manuelo", person.best_friend.name
+    assert_equal "Eggs", person.favourite_foods["Breakfast"]
   end
 
   test "it can extract fields in a nice way" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :best_friend, :message, 3, "pbbuildertest.Person"
       repeated :nicknames, :string, 4
       optional :field_mask, :message, 5, "google.protobuf.FieldMask"
+      map :favourite_foods, :string, :string, 6
     end
   end
 end


### PR DESCRIPTION
Adds simple support for the [`Map` type](https://developers.google.com/protocol-buffers/docs/proto3#maps). I don't attempt to do any sort of fuzzy mapping (e.g. symbol keys to strings) and I didn't add any explicit handling for the values being a Message.