### PR TITLE
Register pb as a template type

### DIFF
--- a/lib/pbbuilder/railtie.rb
+++ b/lib/pbbuilder/railtie.rb
@@ -4,6 +4,7 @@ class Pbbuilder
   class Railtie < ::Rails::Railtie
     initializer :register_handler do
       ActiveSupport.on_load :action_view do
+        ActionView::Template::Types.symbols << :pb
         ActionView::Template.register_template_handler :pbbuilder, PbbuilderHandler
       end
     end


### PR DESCRIPTION
In Rails 7 this needs to be done otherwise the templates can't be found.
This was accidentally working before.