### PR TITLE
prepare for 0.13.0 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         gemfile:
           - "rails_6_1"
           - "rails_7_0"
-          - "rails_head"
+          #- "rails_head"
 
     steps:
       - uses: actions/checkout@v3

--- a/Appraisals
+++ b/Appraisals
@@ -6,6 +6,6 @@ appraise "rails-7-0" do
   gem "rails", "~> 7.0.0"
 end
 
-appraise "rails-head" do
-  gem "rails", github: "rails/rails", branch: "main"
-end
+#appraise "rails-head" do
+#  gem "rails", github: "rails/rails", branch: "main"
+#end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 - TestUnit dependency
 
-### Added
-- Testing agains Rails HEAD branch
-
 
 ## 0.12.0 Prior to 2022-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Pbbuilder Changelog
+All notable changes to this project will be documented in this file.
 
-Note: This library uses semantic versioning.
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-Changed:
-- TestUnit dependency removed
-- Testing agains Rails HEAD branch
+## 0.13.0
+### Changed
 - Appraisal is properly configured to run against all rubies and rails combinations.
-- Supported ruby version's are no 2.7, 3.0, 3.1
+- Supported ruby version's are 2.7, 3.0, 3.1
 - Ruby upgrade: From 3.1.0 to 3.1.2 for the lib itself. The Rubies in test matrix are upgraded to their latest point
   releases; 2.7.6, 3.0.4, and 3.1.2 respectively.
 - Library upgrade: All gems are updated to the latest possible version. Most notable upgrades:
@@ -16,6 +16,13 @@ Changed:
   - `google-protobuf` from version 3.19.2 to 3.21.7 (for both rails versions)
   - `bundler` from version 2.3.4 to 2.3.22
 
-## 1.12.0 Prior to 2022-10-14
+### Removed
+- TestUnit dependency
+
+### Added
+- Testing agains Rails HEAD branch
+
+
+## 0.12.0 Prior to 2022-10-14
 
 A templating language, for protobuf, for Rails, inspired by [Jbuilder](https://github.com/rails/jbuilder)

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = "pbbuilder"
-  spec.version = "0.12.0"
+  spec.version = "0.13.0"
   spec.authors = ["Bouke van der Bijl"]
   spec.email = ["bouke@cheddar.me"]
   spec.homepage = "https://github.com/cheddar-me/pbbuilder"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,8 @@ require "pbbuilder"
 require "google/protobuf"
 require "google/protobuf/field_mask_pb"
 
+require "active_support/testing/autorun"
+
 ActiveSupport.test_order = :random
 
 Google::Protobuf::DescriptorPool.generated_pool.build do


### PR DESCRIPTION
Want to cut a 0.13.0 release for Rubygems.org

also one line that I forgot to add to fix testsuit.