### PR TITLE
Make sure that we're testing against all rails versions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     name: Ruby ${{ matrix.ruby }} (${{ matrix.gemfile }})
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_JOBS: 4
@@ -14,10 +15,19 @@ jobs:
       matrix:
         ruby: ["2.7", "3.0", "3.1"]
 
-        gemfile:
-          - "rails_6_1"
-          - "rails_7_0"
-          #- "rails_head"
+        gemfile: [ "rails_6_1", "rails_7_0"]
+        experimental: [false]
+
+        include:
+          - ruby: '2.7'
+            gemfile: rails_head
+            experimental: true
+          - ruby: '3.0'
+            gemfile: rails_head
+            experimental: true
+          - ruby: '3.1'
+            gemfile: rails_head
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         gemfile:
           - "rails_6_1"
           - "rails_7_0"
-          - "rails_head"
+          #- "rails_head"
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Pbbuilder Changelog
+All notable changes to this project will be documented in this file.
 
-Note: This library uses semantic versioning.
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
-Changed:
-- TestUnit dependency removed
-- Testing agains Rails HEAD branch
+### Changed
 - Appraisal is properly configured to run against all rubies and rails combinations.
-- Supported ruby version's are no 2.7, 3.0, 3.1
+- Supported ruby version's are 2.7, 3.0, 3.1
 - Ruby upgrade: From 3.1.0 to 3.1.2 for the lib itself. The Rubies in test matrix are upgraded to their latest point
   releases; 2.7.6, 3.0.4, and 3.1.2 respectively.
 - Library upgrade: All gems are updated to the latest possible version. Most notable upgrades:
@@ -16,6 +14,10 @@ Changed:
   - `google-protobuf` from version 3.19.2 to 3.21.7 (for both rails versions)
   - `bundler` from version 2.3.4 to 2.3.22
 
-## 1.12.0 Prior to 2022-10-14
+### Removed
+- TestUnit dependency
+
+
+## 0.12.0 Prior to 2022-10-14
 
 A templating language, for protobuf, for Rails, inspired by [Jbuilder](https://github.com/rails/jbuilder)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,8 @@ require "pbbuilder"
 require "google/protobuf"
 require "google/protobuf/field_mask_pb"
 
+require "active_support/testing/autorun"
+
 ActiveSupport.test_order = :random
 
 Google::Protobuf::DescriptorPool.generated_pool.build do


### PR DESCRIPTION
This PR fixes tests.

Previously, we didn't test against all rails versions. But now we do -- against 3 different rails versions.

I added HEAD branch of rails to matrix, but marked it as experimental. We can assume, that this is a 7.2 release of rails.

Currently it's failing - it might be a regression? or not?