### PR TITLE
Introduce Fragment Caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,21 +13,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
 
         gemfile: [ "rails_6_1", "rails_7_0"]
         experimental: [false]
 
-        include:
-          - ruby: '2.7'
-            gemfile: rails_head
-            experimental: true
-          - ruby: '3.0'
-            gemfile: rails_head
-            experimental: true
-          - ruby: '3.1'
-            gemfile: rails_head
-            experimental: true
+        #include:
+        #  - ruby: '2.7'
+        #    gemfile: rails_head
+        #    experimental: true
+        #  - ruby: '3.0'
+        #    gemfile: rails_head
+        #    experimental: true
+        #  - ruby: '3.1'
+        #    gemfile: rails_head
+        #    experimental: true
 
     steps:
       - uses: actions/checkout@v3

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -139,7 +139,7 @@ class Pbbuilder
     end
   end
 
-  # @return Protobuf::?? Binary body of message
+  # @return Initialized message object
   def target!
     @message
   end
@@ -149,7 +149,7 @@ class Pbbuilder
   # Appends protobuf message with existing @message object
   #
   # @param name string
-  # @param descriptor ??
+  # @param descriptor Google::Protobuf::FieldDescriptor
   # @param collection hash
   # @param &block
   def _append_repeated(name, descriptor, collection, &block)
@@ -164,7 +164,7 @@ class Pbbuilder
 
   # Yields an Protobuf object in a scope of message and provided values.
   #
-  # @param message Protobuf::Message::??
+  # @param message Google::Protobuf::(field_type)
   def _scope(message)
     old_message = @message
     @message = message
@@ -176,7 +176,7 @@ class Pbbuilder
 
   # Build up empty protobuf message based on descriptor
   #
-  # @param descriptor Protobuf::Descriptor::??
+  # @param descriptor Google::Protobuf::FieldDescriptor
   def _new_message_from_descriptor(descriptor)
     ::Kernel.raise ::ArgumentError, "can't pass block to non-message field" unless descriptor.type == :message
 

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -1,3 +1,9 @@
+require "pbbuilder/pbbuilder"
+require 'pbbuilder/errors'
+require "pbbuilder/protobuf_extension"
+require "pbbuilder/railtie" if defined?(Rails)
+
+
 # Pbbuilder makes it easy to create a protobuf message using the builder pattern
 # It is heavily inspired by jbuilder
 #
@@ -112,13 +118,13 @@ class Pbbuilder
         ::Kernel.raise ::MergeError.build(target!, object)
       end
 
-      if object[key].class == String
+      if object[key].class == ::String
         # pb.fields {"one" => "two"}
         @message[key.to_s] = object[key]
-      elsif object[key].class == Array
+      elsif object[key].class == ::Array
         # pb.tags ['test', 'ok']
         @message[key.to_s].replace object[key]
-      elsif ( obj = object[key]).class == Hash
+      elsif ( obj = object[key]).class == ::Hash
         # pb.field_name do
         #    pb.tags ["ok", "cool"]
         # end
@@ -183,7 +189,3 @@ class Pbbuilder
     message_class.new
   end
 end
-
-require 'pbbuilder/errors'
-require "pbbuilder/protobuf_extension"
-require "pbbuilder/railtie" if defined?(Rails)

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -23,7 +23,7 @@ require 'pbbuilder/errors'
 # It basically works exactly like jbuilder. The main difference is that it can use introspection to figure out what kind
 # of protobuf message it needs to create.
 
-class Pbbuilder < BasicObject
+class Pbbuilder
   def initialize(message)
     @message = message
 
@@ -106,6 +106,10 @@ class Pbbuilder < BasicObject
   def merge!(object)
     if object.class == ::Hash
       object.each_key do |key|
+        if object[key].empty?
+          raise MergeError.build(@message, object) 
+        end
+
         @message[key.to_s] = object[key]
       end
     else

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -1,6 +1,3 @@
-require 'pbbuilder/errors'
-require 'pry'
-
 # Pbbuilder makes it easy to create a protobuf message using the builder pattern
 # It is heavily inspired by jbuilder
 #
@@ -187,5 +184,6 @@ class Pbbuilder
   end
 end
 
+require 'pbbuilder/errors'
 require "pbbuilder/protobuf_extension"
 require "pbbuilder/railtie" if defined?(Rails)

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -1,3 +1,5 @@
+require 'pbbuilder/errors'
+
 # Pbbuilder makes it easy to create a protobuf message using the builder pattern
 # It is heavily inspired by jbuilder
 #
@@ -98,6 +100,16 @@ class Pbbuilder < BasicObject
     args.each do |arg|
       value = element.send(arg)
       @message[arg.to_s] = value
+    end
+  end
+
+  def merge!(object)
+    if object.class == ::Hash
+      object.each_key do |key|
+        @message[key.to_s] = object[key]
+      end
+    else
+      raise MergeError.build(@message, object)
     end
   end
 

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -107,13 +107,13 @@ class Pbbuilder
     if object.class == ::Hash
       object.each_key do |key|
         if object[key].empty?
-          raise MergeError.build(@message, object) 
+          ::Kernel.raise ::MergeError.build(target!, object) 
         end
 
         @message[key.to_s] = object[key]
       end
     else
-      raise MergeError.build(@message, object)
+      ::Kernel.raise ::MergeError.build(target!, object)
     end
   end
 

--- a/lib/pbbuilder/errors.rb
+++ b/lib/pbbuilder/errors.rb
@@ -1,10 +1,10 @@
 require 'pbbuilder'
 
 class Pbbuilder
-	class MergeError < ::StandardError
+	class MergeError < StandardError
 		def self.build(current_value, updates)
 			message = "Can't merge #{updates.inspect} into #{current_value.inspect}"
-			new(message)
+			self.new(message)
 		end
 	end
 end

--- a/lib/pbbuilder/errors.rb
+++ b/lib/pbbuilder/errors.rb
@@ -1,0 +1,10 @@
+require 'pbbuilder'
+
+class Pbbuilder
+	class MergeError < ::StandardError
+		def self.build(current_value, updates)
+			message = "Can't merge #{updates.inspect} into #{current_value.inspect}"
+			new(message)
+		end
+	end
+end

--- a/lib/pbbuilder/errors.rb
+++ b/lib/pbbuilder/errors.rb
@@ -1,7 +1,7 @@
 require 'pbbuilder'
 
 class Pbbuilder
-	class MergeError < StandardError
+	class MergeError < ::StandardError
 		def self.build(current_value, updates)
 			message = "Can't merge #{updates.inspect} into #{current_value.inspect}"
 			self.new(message)

--- a/lib/pbbuilder/errors.rb
+++ b/lib/pbbuilder/errors.rb
@@ -1,10 +1,10 @@
 require 'pbbuilder'
 
 class Pbbuilder
-	class MergeError < ::StandardError
-		def self.build(current_value, updates)
-			message = "Can't merge #{updates.inspect} into #{current_value.inspect}"
-			self.new(message)
-		end
-	end
+  class MergeError < ::StandardError
+    def self.build(current_value, updates)
+      message = "Can't merge #{updates.inspect} into #{current_value.inspect}"
+      self.new(message)
+    end
+  end
 end

--- a/lib/pbbuilder/pbbuilder.rb
+++ b/lib/pbbuilder/pbbuilder.rb
@@ -1,0 +1,7 @@
+Pbbuilder = Class.new(begin
+  require 'active_support/proxy_object'
+  ActiveSupport::ProxyObject
+rescue LoadError
+  require 'active_support/basic_object'
+  ActiveSupport::BasicObject
+end)

--- a/lib/pbbuilder/railtie.rb
+++ b/lib/pbbuilder/railtie.rb
@@ -1,3 +1,4 @@
+require 'rails'
 require "pbbuilder/handler"
 
 class Pbbuilder

--- a/lib/pbbuilder/template.rb
+++ b/lib/pbbuilder/template.rb
@@ -67,6 +67,19 @@ class PbbuilderTemplate < Pbbuilder
     end
   end
 
+  # Conditionally caches the protobuf message depending on the condition given as first parameter. Has the same
+  # signature as the `cache` helper method in `ActionView::Helpers::CacheHelper` and so can be used in
+  # the same way.
+  #
+  # Example:
+  #
+  #   pb.cache_if! !admin?, @person, expires_in: 10.minutes do
+  #     pb.extract! @person, :name, :age
+  #   end
+  def cache_if!(condition, *args, &block)
+    condition ? cache!(*args, &block) : yield
+  end
+
   private
 
   # Writes to cache, if cache with keys is missing.

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split("\n")
   spec.test_files = `git ls-files -- test/*`.split("\n")
 
-  spec.add_dependency "google-protobuf", "~> 3.19", ">= 3.19.2"
+  spec.add_dependency "google-protobuf"
   spec.add_dependency "activesupport"
   spec.add_development_dependency 'm'
   spec.add_development_dependency "pry"

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "google-protobuf", "~> 3.19", ">= 3.19.2"
   spec.add_dependency "activesupport"
-  spec.add_dependency "pry"
+  spec.add_development_dependency 'm'
+  spec.add_development_dependency "pry"
 end

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -13,4 +13,6 @@ Gem::Specification.new do |spec|
   spec.test_files = `git ls-files -- test/*`.split("\n")
 
   spec.add_dependency "google-protobuf", "~> 3.19", ">= 3.19.2"
+  spec.add_dependency "activesupport"
+  spec.add_dependency "pry"
 end

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -77,6 +77,24 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "Max Verstappen", result.best_friend.name
   end
 
+  test "support for merge! method" do
+    result = render('pb.merge! "name" => "suslik"')
+
+    assert_equal("suslik", result.name)
+  end
+
+  test "object fragment caching" do
+    skip("not working yeat")
+    render(<<-PBBUILDER)
+      pb.cache! "cache-key" do
+        pb.name "Hit"
+      end
+    PBBUILDER
+
+    hit = render('pb.cache! "cache-key" do; end ')
+    assert_equal "Hit", hit["name"]
+  end
+
   private
 
   def render(*args)

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -191,6 +191,31 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "Miss", result["name"]
   end
 
+  test "conditional object fragment caching" do
+    render(<<-JBUILDER)
+      pb.cache_if! true, "cache-key" do
+        pb.name "Hit"
+      end
+
+      pb.cache_if! false, "cache-key" do
+        pb.last_name "Hit"
+      end
+    JBUILDER
+
+    result = render(<<-JBUILDER)
+      pb.cache_if! true, "cache-key" do
+        pb.name "Miss"
+      end
+
+      pb.cache_if! false, "cache-key" do
+        pb.last_name "Miss"
+      end
+    JBUILDER
+
+    assert_equal "Hit", result["name"]
+    assert_equal "Miss", result["last_name"]
+  end
+
   private
 
   def render(*args)

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -108,7 +108,6 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
   end
 
   test "object fragment caching" do
-    skip("not working yeat")
     render(<<-PBBUILDER)
       pb.cache! "cache-key" do
         pb.name "Hit"

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -120,6 +120,34 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "Hit", hit["name"]
   end
 
+  test "fragment caching for arrays" do
+    render <<-PBBUILDER
+      pb.cache! "cache-key" do
+        pb.tags ["ok", "cool"]
+      end
+    PBBUILDER
+
+    result = render('pb.cache! "cache-key" do; end')
+
+    assert_equal(['ok', 'cool'], result.tags)
+  end
+
+  test "optional array fragment caching" do
+    skip('not working right now')
+    
+    render <<-PBBUILDER
+      pb.cache! "cache-key" do
+        pb.field_mask do
+          pb.paths ["ok", "that's", "cool"]
+        end
+      end
+    PBBUILDER
+
+    result = render('pb.cache! "cache-key" do; end')
+
+    assert_equal(["ok", "that's", "cool"], result.field_mask.paths)
+  end
+
   test "object fragment caching with expiry" do
     travel_to Time.iso8601("2018-05-12T11:29:00-04:00")
 

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -93,15 +93,14 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal("Manuelo", result.best_friend.name)
   end
 
-
-  test "should raise MergeError in merge! an empty hash" do
-    assert_raise(Pbbuilder::MergeError) {
+  test "should raise Error in merge! an empty hash" do
+    assert_raise(ActionView::Template::Error) {
       render(<<-PBBUILDER)
         pb.merge! "name" => {}
       PBBUILDER
     }
 
-    assert_raise(Pbbuilder::MergeError) {
+    assert_raise(ActionView::Template::Error) {
       render(<<-PBBUILDER)
         pb.merge! "" => {}
       PBBUILDER

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -133,8 +133,6 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
   end
 
   test "optional array fragment caching" do
-    skip('not working right now')
-    
     render <<-PBBUILDER
       pb.cache! "cache-key" do
         pb.field_mask do

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -109,6 +109,21 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     }
   end
 
+  test "empty fragment caching" do
+    render 'pb.cache! "nothing" do; end'
+
+    result = nil
+
+    assert_nothing_raised do
+      result = render(<<-JBUILDER)
+        pb.name "suslik"
+        pb.cache! "nothing" do; end
+      JBUILDER
+    end
+
+    assert_equal "suslik", result["name"]
+  end
+
   test "object fragment caching" do
     render(<<-PBBUILDER)
       pb.cache! "cache-key" do

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -83,6 +83,31 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal("suslik", result.name)
   end
 
+  test "support for merge! method in a block" do
+    result = render(<<-PBBUILDER)
+      pb.best_friend do
+        pb.merge! "name" => "Manuelo"
+      end
+    PBBUILDER
+
+    assert_equal("Manuelo", result.best_friend.name)
+  end
+
+
+  test "should raise MergeError in merge! an empty hash" do
+    assert_raise(Pbbuilder::MergeError) {
+      render(<<-PBBUILDER)
+        pb.merge! "name" => {}
+      PBBUILDER
+    }
+
+    assert_raise(Pbbuilder::MergeError) {
+      render(<<-PBBUILDER)
+        pb.merge! "" => {}
+      PBBUILDER
+    }
+  end
+
   test "object fragment caching" do
     skip("not working yeat")
     render(<<-PBBUILDER)

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -21,6 +21,8 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     "_person.html.erb" => "Hello world!"
   }
 
+  setup { Rails.cache.clear }
+
   test "basic template" do
     result = render('pb.name "hello"')
     assert_equal "hello", result.name

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       repeated :nicknames, :string, 4
       optional :field_mask, :message, 5, "google.protobuf.FieldMask"
       map :favourite_foods, :string, :string, 6
+      repeated :tags, :string, 7
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_file("pbbuilder.proto", syntax: :proto3) do
     add_message "pbbuildertest.Person" do
       optional :name, :string, 1
+      optional :last_name, :string, 8
       repeated :friends, :message, 2, "pbbuildertest.Person"
       optional :best_friend, :message, 3, "pbbuildertest.Person"
       repeated :nicknames, :string, 4

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,12 @@ module API
   Person = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("pbbuildertest.Person").msgclass
 end
 
+class << Rails
+  def cache
+    @cache ||= ActiveSupport::Cache::MemoryStore.new
+  end
+end
+
 class Racer < Struct.new(:id, :name, :friends, :best_friend)
   extend ActiveModel::Naming
   include ActiveModel::Conversion


### PR DESCRIPTION
resolves #22

This introduces fragment caching to pbbuilder gem, currently supports `cache!` and `cache_if!` methods. 

As a part of this functionality I also:
- Added a `merge!` method
- Fixed testing
- Change superclass from BasicObject to ProxyObject with backwards compatibility to BasicObject.
- Introduced custom Error classes
- Added `activesupport` gem to dependencies
- Loosen google-protobuf dependency


As a follow up, it would be great to introduce `cache_root!` (to cache entire document) -- it should be  way easier to implement and it should be way more performant than a fragment caching.