### PR TITLE
Recover from race condition in ActiveSupport::Cache::FileStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.2 2023.02.3
+### Fixed
+- In case ActiveSupport::Cache::FileStore in Rails is used as a cache, File.atomic_write can have a race condition and fail to rename temporary file. We're attempting to recover from that, by catching this specific error and returning a value.
+
 ## 0.13.1 2023.01.24
 ### Added
 - #merge! to support boolean values

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = "pbbuilder"
-  spec.version = "0.13.1"
+  spec.version = "0.13.2"
   spec.authors = ["Bouke van der Bijl"]
   spec.email = ["bouke@cheddar.me"]
   spec.homepage = "https://github.com/cheddar-me/pbbuilder"


### PR DESCRIPTION
While using `ActiveSupport::Cache::FileStore` as a cache in Rails, there is a chance of race condition that will throw errors during cache write.

This is due to how atomic write is implemented in rails and it will fail on `File#rename` due to missing directory/file. Here:

https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/file/atomic.rb#L50

`File#rename` will throw `SystemCallError`, we recover and return value instead.

For more info, please view:
https://github.com/rails/rails/pull/44151
Error from Cheddar.me:
https://appsignal.com/cheddar-payments/sites/61dc6ccf2cf81d516196d1e9/exceptions/incidents/646?timestamp=2023-02-01T23%3A53%3A01Z