### PR TITLE
Expand caching! support to all possible data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.0
+### Changed
+- #merge! method was refactored to accomodate caching for all data types (especially those that are :repeated)
+
 ## 0.14.0
 ### Added
 - Adding `frozen_string_literal: true` to all files.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ When debugging, make sure to prepend `::Kernel` to any calls such as `puts` as o
 In case, you're looking to use breakpoints for debugging purposes - it's better to use `pry`. Just make sure to [change pbbuilder superclass from `ProxyObject/BasicObject` to `Object`](lib/pbbuilder/pbbuilder.rb).
 
 ## Testing
-Running `bundle exec appraisal rake test` locally will run entire testsuit.
+Running `bundle exec appraisal rake test` locally will run entire testsuit with all version of rails. Or run with only certain version of rails `bundle exec appraisal rails-7-0 rake test`
+
+I you want to run only one test, then `m` utility should help with that. Example:
+`bundle exec appraisal rails-7-0 m test/pbbuilder_template_test.rb:182`
 
 ## Contributing
 Everyone is welcome to contribute.

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ When debugging, make sure to prepend `::Kernel` to any calls such as `puts` as o
 In case, you're looking to use breakpoints for debugging purposes - it's better to use `pry`. Just make sure to [change pbbuilder superclass from `ProxyObject/BasicObject` to `Object`](lib/pbbuilder/pbbuilder.rb).
 
 ## Testing
-Running `bundle exec appraisal rake test` locally will run entire testsuit with all version of rails. Or run with only certain version of rails `bundle exec appraisal rails-7-0 rake test`
+Running `bundle exec appraisal rake test` locally will run entire testsuit with all version of rails. To run tests only for certain rails version do the following `bundle exec appraisal rails-7-0 rake test`
 
-I you want to run only one test, then `m` utility should help with that. Example:
+To run only one tests from file - use `m` utility. Like this:
 `bundle exec appraisal rails-7-0 m test/pbbuilder_template_test.rb:182`
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ When debugging, make sure to prepend `::Kernel` to any calls such as `puts` as o
 
 In case, you're looking to use breakpoints for debugging purposes - it's better to use `pry`. Just make sure to [change pbbuilder superclass from `ProxyObject/BasicObject` to `Object`](lib/pbbuilder/pbbuilder.rb).
 
+## Testing
+Running `bundle exec appraisal rake test` locally will run entire testsuit.
+
 ## Contributing
 Everyone is welcome to contribute.
 

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -147,8 +147,7 @@ class Pbbuilder
           if obj.respond_to?(:to_hash)
             obj.to_hash.each {|k, v| @message[key.to_s][k] = v}
           elsif obj.respond_to?(:to_ary)
-            # probably we need to use .concat here
-            # binding.pry
+            @message[key.to_s] = _scope(@message[key.to_s]) { self.merge!(obj) }
           end
         else
           @message[key.to_s] = _scope(@message[key.to_s]) { self.merge!(obj) }

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -131,10 +131,10 @@ class Pbbuilder
         end
 
         if object[key].respond_to?(:to_hash)
-          object[key].to_hash.each {|k, v| @message[key.to_s][k] = v.dup}
+          object[key].to_hash.each {|k, v| @message[key.to_s][k] = v}
         elsif object[key].respond_to?(:to_ary)
           elements = object[key].map do |obj|
-            descriptor.subtype ? descriptor.subtype.msgclass.new(obj) : obj.dup
+            descriptor.subtype ? descriptor.subtype.msgclass.new(obj) : obj
           end
 
           @message[key.to_s].replace(elements)
@@ -142,26 +142,28 @@ class Pbbuilder
       else
         if object[key].class == ::String
           # pb.fields {"one" => "two"}
-          @message[key.to_s] = object[key].dup
+          @message[key.to_s] = object[key]
         elsif object[key].class == ::TrueClass || object[key].class == ::FalseClass
           # pb.boolean true || false
-          @message[key.to_s] = object[key].dup
+          @message[key.to_s] = object[key]
         elsif object[key].class == ::Array
           # pb.field_name do
           #    pb.tags ["ok", "cool"]
           # end
 
-          @message[key.to_s] = object[key].dup
+          @message[key.to_s] = object[key]
         elsif object[key].class == ::Hash
           if @message[key.to_s].nil?
             @message[key.to_s] = _new_message_from_descriptor(descriptor)
           end
 
           object[key].each do |k, v|
+            # This workaround is required to deal with frozen objects, 
+            # becasue .replace is trying to overwrite string in this blows up is string is frozen.
             if object[key][k].is_a?(Enumerable)
               @message[key.to_s][k.to_s].replace object[key][k]
             else
-              @message[key.to_s][k.to_s] = object[key][k].dup
+              @message[key.to_s][k.to_s] = object[key][k]
             end
           end
         end

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -138,8 +138,6 @@ class Pbbuilder
           end
 
           @message[key.to_s].replace(elements)
-        else
-          @message[key].push object[key]
         end
       else
         if object[key].class == ::String

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -160,7 +160,7 @@ class Pbbuilder
           object[key].each do |k, v|
             # This workaround is required to deal with frozen objects, 
             # becasue .replace is trying to overwrite string in this blows up is string is frozen.
-            if object[key][k].is_a?(Enumerable)
+            if object[key][k].is_a?(::Enumerable)
               @message[key.to_s][k.to_s].replace object[key][k]
             else
               @message[key.to_s][k.to_s] = object[key][k]

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -158,8 +158,8 @@ class Pbbuilder
           end
 
           object[key].each do |k, v|
-            # This workaround is required to deal with frozen objects, 
-            # becasue .replace is trying to overwrite string in this blows up is string is frozen.
+            # This workaround is required to deal with frozen objects,
+            # becasue .replace is trying to overwrite string and it blows if string is frozen.
             if object[key][k].is_a?(::Enumerable)
               @message[key.to_s][k.to_s].replace object[key][k]
             else

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -135,14 +135,24 @@ class Pbbuilder
         # end
         #
 
+        field_descriptor = @message.class.descriptor.lookup(key.to_s)
+
         # optional empty fields don't show up in @message object,
         # we recreate empty message, so we can fill it with values
         if @message[key.to_s].nil?
-          field_descriptor = @message.class.descriptor.lookup(key.to_s)
           @message[key.to_s] = _new_message_from_descriptor(field_descriptor)
         end
 
-        @message[key.to_s] = _scope(@message[key.to_s]) { self.merge!(obj) }
+        if field_descriptor.label == :repeated
+          if obj.respond_to?(:to_hash)
+            obj.to_hash.each {|k, v| @message[key.to_s][k] = v}
+          elsif obj.respond_to?(:to_ary)
+            # probably we need to use .concat here
+            # binding.pry
+          end
+        else
+          @message[key.to_s] = _scope(@message[key.to_s]) { self.merge!(obj) }
+        end
       end
     end
   end

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "pbbuilder"
-  spec.version = "0.14.0"
+  spec.version = "0.15.0"
   spec.authors = ["Bouke van der Bijl"]
   spec.email = ["bouke@cheddar.me"]
   spec.homepage = "https://github.com/cheddar-me/pbbuilder"

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -103,13 +103,13 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
   end
 
   test "should raise Error in merge! an empty hash" do
-    assert_raise(ActionView::Template::Error) {
+    assert_nothing_raised {
       render(<<-PBBUILDER)
         pb.merge! "name" => {}
       PBBUILDER
     }
 
-    assert_raise(ActionView::Template::Error) {
+    assert_nothing_raised {
       render(<<-PBBUILDER)
         pb.merge! "" => {}
       PBBUILDER

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -131,6 +131,20 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "suslik", result["name"]
   end
 
+  test "caching repeated partial" do
+    result = nil
+    template = <<-PBBUILDER
+      pb.cache! "some-random-key" do
+        pb.friends @friends, partial: "racers/racer", as: :racer
+      end
+    PBBUILDER
+    friends = [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
+
+    assert_nothing_raised do
+      result = render(template, friends: friends)
+    end
+  end
+
   test "caching map values" do
     template = <<-PBBUILDER
       pb.cache! "some-random-cache-key" do

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -131,6 +131,16 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "suslik", result["name"]
   end
 
+  test "caching map values" do
+    template = <<-PBBUILDER
+      pb.cache! "some-random-cache-key" do
+        pb.favourite_foods @foods
+      end
+    PBBUILDER
+
+    assert_nothing_raised { render( template, foods: {'pizza' => 'yes', 'borsh' => 'false'})}
+  end
+
   test "object fragment caching" do
     render(<<-PBBUILDER)
       pb.cache! "cache-key" do

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -140,9 +140,13 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     PBBUILDER
     friends = [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
 
-    assert_nothing_raised do
-      result = render(template, friends: friends)
-    end
+    result = assert_nothing_raised { render(template, friends: friends) }
+    assert_equal("Johnny Test", result.friends[0].name)
+    assert_equal("Max Verstappen", result.friends[1].name)
+
+    result = render('pb.cache! "some-random-key" do; end ')
+    assert_equal("Johnny Test", result.friends[0].name)
+    assert_equal("Max Verstappen", result.friends[1].name)
   end
 
   test "caching map values" do
@@ -152,7 +156,13 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
       end
     PBBUILDER
 
-    assert_nothing_raised { render( template, foods: {'pizza' => 'yes', 'borsh' => 'false'})}
+    r = assert_nothing_raised { render( template, foods: {'pizza' => 'yes', 'borsh' => 'false'})}
+    assert_equal('false', r.favourite_foods['borsh'])
+    assert_equal('yes', r.favourite_foods['pizza'])
+
+    result = render('pb.cache! "some-random-cache-key" do; end ')
+    assert_equal('false', result.favourite_foods['borsh'])
+    assert_equal('yes', result.favourite_foods['pizza'])
   end
 
   test "object fragment caching" do

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -132,7 +132,6 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
   end
 
   test "caching repeated partial" do
-    result = nil
     template = <<-PBBUILDER
       pb.cache! "some-random-key" do
         pb.friends @friends, partial: "racers/racer", as: :racer

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ require "google/protobuf"
 require "google/protobuf/field_mask_pb"
 
 require "active_support/testing/autorun"
+require "pry"
 
 ActiveSupport.test_order = :random
 


### PR DESCRIPTION
While caching for regular data types was working as you'd expect, in our internal tests caching with :repeated data types didn't work. This PR expands our caching feature to work with wide range of data types.

Please see added tests for examples.

It was tested on our internal monolith app, by randomly placing caching in most complicated *.pbbuilder files. e.g.
https://github.com/cheddar-me/cheddarsvc/pull/3025