### PR TITLE
update appraisal to resolve missing gems issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ When debugging, make sure to prepend `::Kernel` to any calls such as `puts` as o
 In case, you're looking to use breakpoints for debugging purposes - it's better to use `pry`. Just make sure to [change pbbuilder superclass from `ProxyObject/BasicObject` to `Object`](lib/pbbuilder/pbbuilder.rb).
 
 ## Testing
-Running `bundle exec appraisal rake test` locally will run entire testsuit with all version of rails. To run tests only for certain rails version do the following `bundle exec appraisal rails-7-0 rake test`
+Running `bundle exec appraisal rake test` locally will run entire testsuit with all version of rails. To run tests only for certain rails version do the following `bundle exec appraisal rails-7-0 rake test` or for all with `bundle exec appraisal rake test`.
+
+You might meed to run `bundle exec appraisal install` to retrieve all dependencies.
 
 To run only one tests from file - use `m` utility. Like this:
 `bundle exec appraisal rails-7-0 m test/pbbuilder_template_test.rb:182`


### PR DESCRIPTION
I was unable to lunch gems testsuit, it always errored out with following mistake:

```
~/C/pbbuilder ❯❯❯ bundle exec appraisal rake test                                                                                                                                                                                                                                                                                                                                                                              main ✭ ✱ ◼
Could not find rails-6.1.7, actioncable-6.1.7, actionmailbox-6.1.7, actionmailer-6.1.7, actionpack-6.1.7, actiontext-6.1.7, actionview-6.1.7, activejob-6.1.7, activemodel-6.1.7, activerecord-6.1.7, activestorage-6.1.7, activesupport-6.1.7, railties-6.1.7, nio4r-2.5.8, websocket-driver-0.7.5, mail-2.8.0, rails-dom-testing-2.0.3, rack-2.2.5, rack-test-2.0.2, rails-html-sanitizer-1.4.4, nokogiri-1.13.10-arm64-darwin, erubi-1.11.0, globalid-1.0.0, mini_mime-1.1.2, zeitwerk-2.6.6, sprockets-4.1.1, net-imap-0.3.2, loofah-2.19.1, racc-1.6.1, date-3.3.1 in locally installed gems
Run `bundle install` to install missing gems.
>> Reinstall Bundler into /Users/skatkov/.rvm/gems/ruby-3.2.2
Could not find rails-6.1.7, actioncable-6.1.7, actionmailbox-6.1.7, actionmailer-6.1.7, actionpack-6.1.7, actiontext-6.1.7, actionview-6.1.7, activejob-6.1.7, activemodel-6.1.7, activerecord-6.1.7, activestorage-6.1.7, activesupport-6.1.7, railties-6.1.7, nio4r-2.5.8, websocket-driver-0.7.5, mail-2.8.0, rails-dom-testing-2.0.3, rack-2.2.5, rack-test-2.0.2, rails-html-sanitizer-1.4.4, nokogiri-1.13.10-arm64-darwin, erubi-1.11.0, globalid-1.0.0, mini_mime-1.1.2, zeitwerk-2.6.6, sprockets-4.1.1, net-imap-0.3.2, loofah-2.19.1, racc-1.6.1, date-3.3.1 in locally installed gems
Run `bundle install` to install missing gems.
```

I tried usual ways to `appraisail install` or `appraisal update`, but those didn't help. But updating this gem helped, so commiting that.