### PR TITLE
handle recursive protobuf messages

### DIFF
--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -162,6 +162,13 @@ class Pbbuilder
     @message
   end
 
+  def new_message_for(field)
+    descriptor = _descriptor_for_field(field)
+    ::Kernel.raise ::ArgumentError, "Unknown field #{field}" if descriptor.nil?
+
+    _new_message_from_descriptor(descriptor)
+  end
+
   private
 
   def _descriptor_for_field(field)

--- a/lib/pbbuilder/collection_renderer.rb
+++ b/lib/pbbuilder/collection_renderer.rb
@@ -16,15 +16,15 @@ class Pbbuilder
     end
 
     def build_rendered_collection(templates, _spacer)
-      pb_root.set!(field, templates.map(&:body))
+      pb_parent.set!(field, templates.map(&:body))
     end
 
     def pb
       @options[:locals].fetch(:pb)
     end
 
-    def pb_root
-      @options[:locals].fetch(:pb_root)
+    def pb_parent
+      @options[:locals].fetch(:pb_parent)
     end
 
     def field

--- a/lib/pbbuilder/collection_renderer.rb
+++ b/lib/pbbuilder/collection_renderer.rb
@@ -16,11 +16,15 @@ class Pbbuilder
     end
 
     def build_rendered_collection(templates, _spacer)
-      pb.set!(field, templates.map(&:body))
+      pb_root.set!(field, templates.map(&:body))
     end
 
     def pb
       @options[:locals].fetch(:pb)
+    end
+
+    def pb_root
+      @options[:locals].fetch(:pb_root)
     end
 
     def field

--- a/lib/pbbuilder/template.rb
+++ b/lib/pbbuilder/template.rb
@@ -54,7 +54,7 @@ class PbbuilderTemplate < Pbbuilder
         # but also needs locals[:pb_root] to apply rendered partial to top level protobuf message.
 
         # This logic could be found in CollectionRenderer#build_rendered_collection method that we overwrote.
-        options[:locals].merge!(pb: self.class.new(@context, new_message_for(field)))
+        options[:locals].merge!(pb: ::PbbuilderTemplate.new(@context, new_message_for(field)))
         options[:locals].merge!(pb_root: self)
         options[:locals].merge!(field: field)
 

--- a/lib/pbbuilder/template.rb
+++ b/lib/pbbuilder/template.rb
@@ -49,13 +49,19 @@ class PbbuilderTemplate < Pbbuilder
 
         collection = options[:collection] || []
         partial = options[:partial]
-        options[:locals].merge!(pb: self)
+
+        # CollectionRenderer uses locals[:pb] to render the partial as a protobuf message,
+        # but also needs locals[:pb_root] to apply rendered partial to top level protobuf message.
+
+        # This logic could be found in CollectionRenderer#build_rendered_collection method that we overwrote.
+        options[:locals].merge!(pb: self.class.new(@context, new_message_for(field)))
+        options[:locals].merge!(pb_root: self)
         options[:locals].merge!(field: field)
 
         if options.has_key?(:layout)
           raise ::NotImplementedError, "The `:layout' option is not supported in collection rendering."
         end
-  
+
         if options.has_key?(:spacer_template)
           raise ::NotImplementedError, "The `:spacer_template' option is not supported in collection rendering."
         end

--- a/lib/pbbuilder/template.rb
+++ b/lib/pbbuilder/template.rb
@@ -50,12 +50,15 @@ class PbbuilderTemplate < Pbbuilder
         collection = options[:collection] || []
         partial = options[:partial]
 
-        # CollectionRenderer uses locals[:pb] to render the partial as a protobuf message,
-        # but also needs locals[:pb_root] to apply rendered partial to top level protobuf message.
+        # The way recursive rendering works is that CollectionRenderer needs to be aware of node its currently rendering and parent node,
+        # these is no need to know entire "stack" of nodes. CollectionRenderer would traverse to bottom node render that first and then go up in stack.
 
-        # This logic could be found in CollectionRenderer#build_rendered_collection method that we overwrote.
+        # CollectionRenderer uses locals[:pb] to render the partial as a protobuf message,
+        # but also needs locals[:pb_parent] to apply rendered partial to top level protobuf message.
+
+        # This logic could be found in CollectionRenderer#build_rendered_collection method that we over wrote.
         options[:locals].merge!(pb: ::PbbuilderTemplate.new(@context, new_message_for(field)))
-        options[:locals].merge!(pb_root: self)
+        options[:locals].merge!(pb_parent: self)
         options[:locals].merge!(field: field)
 
         if options.has_key?(:layout)

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "pbbuilder"
-  spec.version = "0.16.0"
+  spec.version = "0.16.1"
   spec.authors = ["Bouke van der Bijl"]
   spec.email = ["bouke@cheddar.me"]
   spec.homepage = "https://github.com/cheddar-me/pbbuilder"

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -39,15 +39,19 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
   end
 
   test "render collections with partial as kwarg" do
-    result = render('pb.friends partial: "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", [], nil, API::Asset.new(url: "https://google.com/test.svg")), Racer.new(2, "Max Verstappen", [])]')
+    template = <<-PBBUILDER
+      more_friends = [Racer.new(4, "Johnny Brave", [], nil, API::Asset.new(url: "https://google.com/test3.svg"))]
+      friends_of_racer = [Racer.new(3, "Chris Harris", more_friends, nil, API::Asset.new(url: "https://google.com/test2.svg"))]
+      racers = [Racer.new(1, "Johnny Test", friends_of_racer, nil, API::Asset.new(url: "https://google.com/test1.svg")), Racer.new(2, "Max Verstappen", [])]
+      pb.friends partial: "racers/racer", as: :racer, collection: racers
+    PBBUILDER
+    result = render(template)
 
     assert_equal 2, result.friends.count
     assert_nil result.logo
-    result.friends.first.logo.tap do |logo|
-      assert_equal "https://google.com/test.svg", logo.url
-      assert_equal "https://google.com/test.svg", logo.url_2x
-      assert_equal "https://google.com/test.svg", logo.url_3x
-    end
+    assert_equal "https://google.com/test1.svg", result.friends.first.logo.url
+    assert_equal "https://google.com/test2.svg", result.friends.first.friends.first.logo.url
+    assert_equal "https://google.com/test3.svg", result.friends.first.friends.first.friends.first.logo.url
   end
 
   test "CollectionRenderer: raises an error on a render with :layout option" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,6 +46,7 @@ end
 
 module API
   Person = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("pbbuildertest.Person").msgclass
+  Asset = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("pbbuildertest.Asset").msgclass
 end
 
 class << Rails
@@ -54,7 +55,7 @@ class << Rails
   end
 end
 
-class Racer < Struct.new(:id, :name, :friends, :best_friend)
+class Racer < Struct.new(:id, :name, :friends, :best_friend, :logo)
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 end


### PR DESCRIPTION
In previous implementation, CollectionRenderer cannot handle recursive protobuf messages, but this fix resolves it.