### PR TITLE
Enable collection renderer for all collection-like objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.2
+### Changed
+- All collection-like objects are rendered with ActiveView::CollectionRenderer
+
+## 0.16.1
+### Changed
+- Deal properly with recursive protobuf messages while using ActiveView::CollectionRenderer
+
 ## 0.16.0
 ### Added
 - Added support for new collection rendering, that is backed by ActiveView::CollectionRenderer.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pb.accounts @accounts, partial: "account", as: account
 ```
 
 ## Collections (or Arrays)
-There are two different methods to render a collection. One that uses ActiveView::CollectionRenderer
+There are two different methods to render a collection.
 ```ruby
 pb.friends partial: "racers/racer", as: :racer, collection: @racers
 ```
@@ -91,7 +91,6 @@ pb.friends partial: "racers/racer", as: :racer, collection: @racers
 pb.friends "racers/racer", as: :racer, collection: @racers
 ```
 
-And there are other ways, that don't use Collection Renderer (not very effective probably)
 ```ruby
 pb.partial! @racer, racer: Racer.new(123, "Chris Harris", friends)
 ```

--- a/lib/pbbuilder/template.rb
+++ b/lib/pbbuilder/template.rb
@@ -43,12 +43,11 @@ class PbbuilderTemplate < Pbbuilder
       if args.one? && kwargs.has_key?(:as)
         # pb.friends @friends, partial: "friend", as: :friend
         # Call set! on the super class, passing in a block that renders a partial for every element
-        super(field, *args) do |element|
-          _set_inline_partial(element, kwargs)
-        end
+
+        _render_collection_with_options(field, args.flatten, kwargs)
       elsif kwargs.has_key?(:collection) && kwargs.has_key?(:as)
         # pb.friends partial: "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
-        _render_collection_with_options(field, kwargs[:collection], kwargs.deep_dup)
+        _render_collection_with_options(field, kwargs[:collection], kwargs)
       else
         # pb.best_friend partial: "person", person: @best_friend
         # Call set! as a submessage, passing in the kwargs as partial options
@@ -57,7 +56,13 @@ class PbbuilderTemplate < Pbbuilder
         end
       end
     else
-      super
+      if args.one? && kwargs.has_key?(:collection) && kwargs.has_key?(:as)
+        # pb.friends "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
+
+        _render_collection_with_options(field, kwargs[:collection], kwargs.merge(partial: args.first))
+      else
+        super
+      end
     end
   end
 

--- a/lib/pbbuilder/template.rb
+++ b/lib/pbbuilder/template.rb
@@ -30,6 +30,13 @@ class PbbuilderTemplate < Pbbuilder
     end
   end
 
+  # Set value in a field in message.
+  #
+  # @example
+  #  pb.friends @friends, partial: "friend", as: :friend
+  #  pb.friends partial: "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
+  #  pb.best_friend partial: "person", person: @best_friend
+
   def set!(field, *args, **kwargs, &block)
     # If partial options are being passed, we render a submessage with a partial
     if kwargs.has_key?(:partial)
@@ -41,37 +48,7 @@ class PbbuilderTemplate < Pbbuilder
         end
       elsif kwargs.has_key?(:collection) && kwargs.has_key?(:as)
         # pb.friends partial: "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
-        # collection renderer
-        options = kwargs.deep_dup
-
-        options.reverse_merge! locals: options.except(:partial, :as, :collection, :cached)
-        options.reverse_merge! ::PbbuilderTemplate.template_lookup_options
-
-        collection = options[:collection] || []
-        partial = options[:partial]
-
-        # The way recursive rendering works is that CollectionRenderer needs to be aware of node its currently rendering and parent node,
-        # these is no need to know entire "stack" of nodes. CollectionRenderer would traverse to bottom node render that first and then go up in stack.
-
-        # CollectionRenderer uses locals[:pb] to render the partial as a protobuf message,
-        # but also needs locals[:pb_parent] to apply rendered partial to top level protobuf message.
-
-        # This logic could be found in CollectionRenderer#build_rendered_collection method that we over wrote.
-        options[:locals].merge!(pb: ::PbbuilderTemplate.new(@context, new_message_for(field)))
-        options[:locals].merge!(pb_parent: self)
-        options[:locals].merge!(field: field)
-
-        if options.has_key?(:layout)
-          raise ::NotImplementedError, "The `:layout' option is not supported in collection rendering."
-        end
-
-        if options.has_key?(:spacer_template)
-          raise ::NotImplementedError, "The `:spacer_template' option is not supported in collection rendering."
-        end
-
-        CollectionRenderer
-          .new(@context.lookup_context, options) { |&block| _scope(message[field.to_s],&block) }
-          .render_collection_with_partial(collection, partial, @context, nil)
+        _render_collection_with_options(field, kwargs[:collection], kwargs.deep_dup)
       else
         # pb.best_friend partial: "person", person: @best_friend
         # Call set! as a submessage, passing in the kwargs as partial options
@@ -118,6 +95,38 @@ class PbbuilderTemplate < Pbbuilder
   end
 
   private
+
+  # Uses ActionView::CollectionRenderer to render collection effectively (and users fragment caching)
+  #
+  # The way recursive rendering works is that CollectionRenderer needs to be aware of node its currently rendering and parent node,
+  # these is no need to know entire "stack" of nodes. CollectionRenderer would traverse to bottom node render that first and then go up in stack.
+
+  # CollectionRenderer uses locals[:pb] to render the partial as a protobuf message,
+  # but also needs locals[:pb_parent] to apply rendered partial to top level protobuf message.
+
+  # This logic could be found in CollectionRenderer#build_rendered_collection method that we over wrote.
+  def _render_collection_with_options(field, collection, options)
+    partial = options[:partial]
+
+    options.reverse_merge! locals: options.except(:partial, :as, :collection, :cached)
+    options.reverse_merge! ::PbbuilderTemplate.template_lookup_options
+
+    options[:locals].merge!(pb: ::PbbuilderTemplate.new(@context, new_message_for(field)))
+    options[:locals].merge!(pb_parent: self)
+    options[:locals].merge!(field: field)
+
+    if options.has_key?(:layout)
+      raise ::NotImplementedError, "The `:layout' option is not supported in collection rendering."
+    end
+
+    if options.has_key?(:spacer_template)
+      raise ::NotImplementedError, "The `:spacer_template' option is not supported in collection rendering."
+    end
+
+    CollectionRenderer
+      .new(@context.lookup_context, options) { |&block| _scope(message[field.to_s],&block) }
+      .render_collection_with_partial(collection, partial, @context, nil)
+  end
 
   # Writes to cache, if cache with keys is missing.
   #

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "pbbuilder"
-  spec.version = "0.16.1"
+  spec.version = "0.16.2"
   spec.authors = ["Bouke van der Bijl"]
   spec.email = ["bouke@cheddar.me"]
   spec.homepage = "https://github.com/cheddar-me/pbbuilder"

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -54,6 +54,21 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "https://google.com/test3.svg", result.friends.first.friends.first.friends.first.logo.url
   end
 
+  test "partial by name with caching" do
+    template = <<-PBBUILDER
+      racers = [Racer.new(1, "Johnny Test", [], nil, API::Asset.new(url: "https://google.com/test1.svg")), Racer.new(2, "Max Verstappen", [])]
+      pb.friends partial: "racers/racer", as: :racer, collection: racers, cached: true
+    PBBUILDER
+
+    assert_difference('Rails.cache.instance_variable_get(:@data).size') do
+      result = render(template)
+    end
+
+    assert_equal 2, result.friends.count
+    assert_nil result.logo
+    assert_equal "https://google.com/test1.svg", result.friends.first.logo.url
+  end
+
   test "CollectionRenderer: raises an error on a render with :layout option" do
     error = assert_raises NotImplementedError do
       render('pb.friends partial: "racers/racer", as: :racer, layout: "layout", collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]')

--- a/test/pbbuilder_template_test.rb
+++ b/test/pbbuilder_template_test.rb
@@ -54,21 +54,6 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
     assert_equal "https://google.com/test3.svg", result.friends.first.friends.first.friends.first.logo.url
   end
 
-  test "partial by name with caching" do
-    template = <<-PBBUILDER
-      racers = [Racer.new(1, "Johnny Test", [], nil, API::Asset.new(url: "https://google.com/test1.svg")), Racer.new(2, "Max Verstappen", [])]
-      pb.friends partial: "racers/racer", as: :racer, collection: racers, cached: true
-    PBBUILDER
-
-    assert_difference('Rails.cache.instance_variable_get(:@data).size') do
-      result = render(template)
-    end
-
-    assert_equal 2, result.friends.count
-    assert_nil result.logo
-    assert_equal "https://google.com/test1.svg", result.friends.first.logo.url
-  end
-
   test "CollectionRenderer: raises an error on a render with :layout option" do
     error = assert_raises NotImplementedError do
       render('pb.friends partial: "racers/racer", as: :racer, layout: "layout", collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]')
@@ -86,7 +71,6 @@ class PbbuilderTemplateTest < ActiveSupport::TestCase
   end
 
   test "render collections with partial as arg" do
-    skip("This will be addressed in future version of a gem")
     result = render('pb.friends "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]')
 
     assert_equal 2, result.friends.count


### PR DESCRIPTION
We've seen good performance gains from using `ActionView::CollectionRenderer`, let's now use it for all collection like objects.