### PR TITLE
fragment caching, partial as first argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.16.2
+### Added
+- Add support for partial as a first argument , e.g.`pb.friends "racers/racer", as: :racer, collection: @racers`
+- Add tests to verify that fragment caching is operational
+
+## 0.16.1
+### Changed
+- Deal properly with recursive protobuf messages while using ActiveView::CollectionRenderer
+
 ## 0.16.0
 ### Added
 - Added support for new collection rendering, that is backed by ActiveView::CollectionRenderer.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We don't aim to have 100% compitability and coverage with jbuilder gem, but we c
 |  cache! | ✅ | ✅ |
 |  cache_if! | ✅ | ✅ |
 | cache_root! | ✅|  |
-| collection cache | ✅|  |
+| fragment cache | ✅| ✅ |
 | extract! | ✅ | ✅ |
 | merge! | ✅ | ✅ |
 | child! | ✅ |  |
@@ -116,7 +116,15 @@ pb.cache_if! !admin?, "cache-key", expires_in: 10.minutes do
 end
 ```
 
-Fragment caching support is currently in the works.
+Fragment caching currently works through ActionView::CollectionRenderer.
+
+```ruby
+pb.friends partial: "racers/racer", as: :racer, collection: @racers, cached: true
+```
+
+```ruby
+pb.friends "racers/racer", as: :racer, collection: @racers, cached: true
+```
 
 ## Installation
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pb.cache_if! !admin?, "cache-key", expires_in: 10.minutes do
 end
 ```
 
-Fragment caching currently works through ActionView::CollectionRenderer and can be used only with following syntax:
+Fragment caching currently works through ActionView::CollectionRenderer and can be used only with the following syntax:
 
 ```ruby
 pb.friends partial: "racers/racer", as: :racer, collection: @racers, cached: true

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pb.cache_if! !admin?, "cache-key", expires_in: 10.minutes do
 end
 ```
 
-Fragment caching currently works through ActionView::CollectionRenderer.
+Fragment caching currently works through ActionView::CollectionRenderer and can be used only with following syntax:
 
 ```ruby
 pb.friends partial: "racers/racer", as: :racer, collection: @racers, cached: true

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -57,12 +57,14 @@ class Pbbuilder
       ::Kernel.raise ::ArgumentError, "can't pass block to non-message field" unless descriptor.type == :message
 
       if descriptor.label == :repeated
-        # pb.field @array { |element| pb.name element.name }
+        # example syntax that should end up here:
+        #    pb.field @array { |element| pb.name element.name }
         ::Kernel.raise ::ArgumentError, "wrong number of arguments #{args.length} (expected 1)" unless args.length == 1
         collection = args.first
         _append_repeated(name, descriptor, collection, &block)
       else
-        # pb.field { pb.name "hello" }
+        # example syntax that should end up here:
+        #   pb.field { pb.name "hello" }
         ::Kernel.raise ::ArgumentError, "wrong number of arguments (expected 0)" unless args.empty?
         message = (@message[name] ||= _new_message_from_descriptor(descriptor))
         _scope(message, &block)
@@ -71,7 +73,8 @@ class Pbbuilder
       arg = args.first
       if descriptor.label == :repeated
         if arg.respond_to?(:to_hash)
-          # pb.fields {"one" => "two"}
+          # example syntax that should end up here:
+          #   pb.fields {"one" => "two"}
           arg.to_hash.each { |k, v| @message[name][k] = v }
         elsif arg.respond_to?(:to_ary) && !descriptor.type.eql?(:message)
           # pb.fields ["one", "two"]
@@ -79,20 +82,23 @@ class Pbbuilder
 
           @message[name].concat arg.to_ary
         elsif arg.respond_to?(:to_ary) && descriptor.type.eql?(:message)
-          # pb.friends [Person.new(name: "Johnny Test"), Person.new(name: "Max Verstappen")]
-          # Concat another Protobuf message into parent Protobuf message (not ary of strings)
+          # example syntax that should end up here:
+          #   pb.friends [Person.new(name: "Johnny Test"), Person.new(name: "Max Verstappen")]
 
           args.flatten.each {|obj| @message[name].push descriptor.subtype.msgclass.new(obj)}
         else
-          # pb.fields "one"
+          # example syntax that should end up here:
+          #   pb.fields "one"
           @message[name].push arg
         end
       else
-        # pb.field "value"
+        # example syntax that should end up here:
+        #   pb.field "value"
         @message[name] = arg
       end
     else
-      # pb.field @value, :id, :name, :url
+      # example syntax that should end up here:
+      #   pb.field @value, :id, :name, :url
       element = args.shift
       if descriptor.label == :repeated
         # If the message field that's being assigned is a repeated field, then we assume that `element` is enumerable.

--- a/lib/pbbuilder/template.rb
+++ b/lib/pbbuilder/template.rb
@@ -30,7 +30,7 @@ class PbbuilderTemplate < Pbbuilder
     end
   end
 
-  # Set value in a field in message.
+  # Set the value in the message field.
   #
   # @example
   #  pb.friends @friends, partial: "friend", as: :friend
@@ -42,25 +42,29 @@ class PbbuilderTemplate < Pbbuilder
     # If partial options are being passed, we render a submessage with a partial
     if kwargs.has_key?(:partial)
       if args.one? && kwargs.has_key?(:as)
-        # pb.friends @friends, partial: "friend", as: :friend
+        # example syntax that should end up here:
+        #   pb.friends @friends, partial: "friend", as: :friend
         # Call set! on the super class, passing in a block that renders a partial for every element
         super(field, *args) do |element|
           _set_inline_partial(element, kwargs)
         end
       elsif kwargs.has_key?(:collection) && kwargs.has_key?(:as)
-        # pb.friends partial: "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
+        # example syntax that should end up here:
+        #   pb.friends partial: "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
 
         _render_collection_with_options(field, kwargs[:collection], kwargs)
       else
+        # # example syntax that should end up here:
         # pb.best_friend partial: "person", person: @best_friend
-        # Call set! as a submessage, passing in the kwargs as partial options
+
         super(field, *args) do
           _render_partial_with_options(kwargs)
         end
       end
     else
       if args.one? && kwargs.has_key?(:collection) && kwargs.has_key?(:as)
-        # pb.friends "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
+        # example syntax that should end up here:
+        #   pb.friends "racers/racer", as: :racer, collection: [Racer.new(1, "Johnny Test", []), Racer.new(2, "Max Verstappen", [])]
         _render_collection_with_options(field, kwargs[:collection], kwargs.merge(partial: args.first))
       else
         super
@@ -103,15 +107,16 @@ class PbbuilderTemplate < Pbbuilder
 
   private
 
-  # Uses ActionView::CollectionRenderer to render collection effectively (and users fragment caching)
+  # Uses ActionView::CollectionRenderer to render collection effectively and to use rails built in fragment caching support.
   #
-  # The way recursive rendering works is that CollectionRenderer needs to be aware of node its currently rendering and parent node,
-  # these is no need to know entire "stack" of nodes. CollectionRenderer would traverse to bottom node render that first and then go up in stack.
+  # The way recursive rendering works is that the CollectionRenderer needs to be aware of the node its currently rendering and parent node.
+  # There is no need to know the entire "stack" of nodes. ActionView::CollectionRenderer would traverse to bottom node render it first and then go one leve up in stack,
+  # rince and repeat until entire stack is rendered.
 
   # CollectionRenderer uses locals[:pb] to render the partial as a protobuf message,
-  # but also needs locals[:pb_parent] to apply rendered partial to top level protobuf message.
+  # but also needs locals[:pb_parent] to apply the rendered partial to the top level protobuf message.
 
-  # This logic could be found in CollectionRenderer#build_rendered_collection method that we over wrote.
+  # This logic can be found in CollectionRenderer#build_rendered_collection method that we overwrote.
   def _render_collection_with_options(field, collection, options)
     partial = options[:partial]
 
@@ -138,7 +143,6 @@ class PbbuilderTemplate < Pbbuilder
   # Writes to cache, if cache with keys is missing.
   #
   # @return fragment value
-
   def _cache_fragment_for(key, options, &block)
     key = _cache_key(key, options)
     _read_fragment_cache(key, options) || _write_fragment_cache(key, options, &block)

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "pbbuilder"
-  spec.version = "0.16.1"
+  spec.version = "0.16.2"
   spec.authors = ["Bouke van der Bijl"]
   spec.email = ["bouke@cheddar.me"]
   spec.homepage = "https://github.com/cheddar-me/pbbuilder"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,7 +59,7 @@ class Racer < Struct.new(:id, :name, :friends, :best_friend, :logo)
   extend ActiveModel::Naming
   include ActiveModel::Conversion
 
-  # For compatibility with ActiveModel::API.
+  # Fragment caching needs to know, if record could be persisted. We set it to false, this is a default in ActiveModel::API.
   def persisted?
     false
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,6 +58,11 @@ end
 class Racer < Struct.new(:id, :name, :friends, :best_friend, :logo)
   extend ActiveModel::Naming
   include ActiveModel::Conversion
+
+  # For compatibility with ActiveModel::API.
+  def persisted?
+    false
+  end
 end
 
 Mime::Type.register "application/vnd.google.protobuf", :pb, [], %w(pb)


### PR DESCRIPTION
Adds ability to provide partial as first argument.

```ruby
pb.friends "racers/racer", as: :racer, collection: @racers
```

Also in detail explains how fragment caching works now and tests that verify that it stays working.