### PR TITLE
Replace repeated messages instead of appending more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@ All notable changes to this project will be documented in this file.
 
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
-### Fixed
-- Fixed CI by locking 3 version of google-protobuf dependency
+## 0.17.0
+### Changed
+- Instead of appending to repeated enum message, we're replacing it to avoid issues in case output will be rendered twice
+- If one field was defined twice, only last definition will end up in output
+
+## Fixed
+- Fixed CI by locking 3 version or lower of google-protobuf dependency.
 
 ## 0.16.2
 ### Added

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -75,12 +75,12 @@ class Pbbuilder
         if arg.respond_to?(:to_hash)
           # example syntax that should end up here:
           #   pb.fields {"one" => "two"}
+
           arg.to_hash.each { |k, v| @message[name][k] = v }
         elsif arg.respond_to?(:to_ary) && !descriptor.type.eql?(:message)
           # pb.fields ["one", "two"]
-          # Using concat so it behaves the same as _append_repeated
 
-          @message[name].concat arg.to_ary
+          @message[name].replace arg.to_ary
         elsif arg.respond_to?(:to_ary) && descriptor.type.eql?(:message)
           # example syntax that should end up here:
           #   pb.friends [Person.new(name: "Johnny Test"), Person.new(name: "Max Verstappen")]
@@ -89,11 +89,13 @@ class Pbbuilder
         else
           # example syntax that should end up here:
           #   pb.fields "one"
-          @message[name].push arg
+
+          @message[name].replace [arg]
         end
       else
         # example syntax that should end up here:
         #   pb.field "value"
+        
         @message[name] = arg
       end
     else

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "pbbuilder"
-  spec.version = "0.16.2"
+  spec.version = "0.17.0"
   spec.authors = ["Bouke van der Bijl"]
   spec.email = ["bouke@cheddar.me"]
   spec.homepage = "https://github.com/cheddar-me/pbbuilder"

--- a/test/pbbuilder_test.rb
+++ b/test/pbbuilder_test.rb
@@ -25,9 +25,36 @@ class PbbuilderTest < ActiveSupport::TestCase
 
     assert_equal "Hello world", person.name
     assert_equal "Friend #1", person.friends.first.name
-    assert_equal ["ok", "that's", "cool"], person.field_mask.paths
+    assert_equal ["cool"], person.field_mask.paths
     assert_equal "Manuelo", person.best_friend.name
     assert_equal "Eggs", person.favourite_foods["Breakfast"]
+  end
+
+  test "replaces the repeated field's value with the last one set" do
+    person = Pbbuilder.new(API::Person.new) do |pb|
+      pb.field_mask do
+        pb.paths ["ok", "that's"]
+      end
+    end.target!
+
+    p = Pbbuilder.new(person) do |pb|
+      pb.field_mask do
+        pb.paths ["ok", "that's"]
+      end
+    end.target!
+
+    assert_equal(["ok", "that's"], p.field_mask.paths)
+  end
+  
+  test "sets the last value of the repeated field to be the only value" do
+    person = Pbbuilder.new(API::Person.new) do |pb|
+      pb.field_mask do
+        pb.paths ["ok", "that's"]
+        pb.paths ["cool"]
+      end
+    end.target!
+
+    assert_equal ["cool"], person.field_mask.paths
   end
 
   test "it can extract fields in a nice way" do


### PR DESCRIPTION
Two bug fixes in one!



# Double definition bug

```
pb.messages "This is the first string of the repeating ones"
pb.messages "This is the second one"
```

This code right now equals to this:

`pb.messages ["This is the first string of the repeating ones", "This is the second one"] `

But jbuilder handles this case differently. So in this PR behaviour is change to one similar to jbuilder - only last definition will be persisted and first one will be discarded.

`pb.messages ["This is the second one"]`

# Double render bug
It seems that rails-twirp gem does double rendering and we're having fields with duplicated values. e.g.

`pb.redemption_methods [:instore, :online]`

could end up with as `[:instore, :online, :instore, :online]`
