### PR TITLE
Fixing CI: lock google-protobuf to ~> 3 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Fixed
+- Fixed CI by locking 3 version of google-protobuf dependency
+
 ## 0.16.2
 ### Added
 - Add support for partial as a first argument , e.g.`pb.friends "racers/racer", as: :racer, collection: @racers`

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split("\n")
   spec.test_files = `git ls-files -- test/*`.split("\n")
 
-  spec.add_dependency "google-protobuf"
+  spec.add_dependency "google-protobuf", "~> 3.25"
   spec.add_dependency "activesupport"
   spec.add_development_dependency 'm'
   spec.add_development_dependency "pry"


### PR DESCRIPTION
google-protobuf v4 comes with a bunch of breaking changes.

Examples:
- https://protobuf.dev/news/2024-01-05/
- https://protobuf.dev/news/2024-01-31/

And our CI seems to be breaking along those breaking changes. Locking version to v3 or below makes it green again.
