### PR TITLE
Allow literal assignment of protos to fields

### DIFF
--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -84,9 +84,10 @@ class Pbbuilder
         elsif arg.respond_to?(:to_ary) && descriptor.type.eql?(:message)
           # pb.friends [Person.new(name: "Johnny Test"), Person.new(name: "Max Verstappen")]
           #
-          # This acceopts both objects that can be to_hash-translated into keyword arguments
-          # for creating a nested Protobuf message, and actual proto messages which can
-          # be assigned "as is". With "as-is" assignment the proto message can be stored
+          # Accepts both objects that can be to_hash-translated into keyword arguments
+          # for creating a nested proto message object and actual proto message objects
+          # which can be assigned "as is". With "as-is" assignment the proto message can be stored
+          # in memory and reused
           nested_messages = arg.map do |arg_member_message_or_hash|
             # If the arg passed already is a proto message and is the same as the
             # field expects - just use it as-is

--- a/lib/pbbuilder.rb
+++ b/lib/pbbuilder.rb
@@ -82,14 +82,24 @@ class Pbbuilder
 
           @message[name].replace arg.to_ary
         elsif arg.respond_to?(:to_ary) && descriptor.type.eql?(:message)
-          # example syntax that should end up here:
-          #   pb.friends [Person.new(name: "Johnny Test"), Person.new(name: "Max Verstappen")]
-
-          args.flatten.each {|obj| @message[name].push descriptor.subtype.msgclass.new(obj)}
+          # pb.friends [Person.new(name: "Johnny Test"), Person.new(name: "Max Verstappen")]
+          #
+          # This acceopts both objects that can be to_hash-translated into keyword arguments
+          # for creating a nested Protobuf message, and actual proto messages which can
+          # be assigned "as is". With "as-is" assignment the proto message can be stored
+          nested_messages = arg.map do |arg_member_message_or_hash|
+            # If the arg passed already is a proto message and is the same as the
+            # field expects - just use it as-is
+            if arg_member_message_or_hash.is_a?(descriptor.subtype.msgclass)
+              arg_member_message_or_hash
+            else
+              descriptor.subtype.msgclass.new(arg_member_message_or_hash)
+            end
+          end
+          @message[name].replace(nested_messages)
         else
           # example syntax that should end up here:
           #   pb.fields "one"
-
           @message[name].replace [arg]
         end
       else

--- a/pbbuilder.gemspec
+++ b/pbbuilder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "pbbuilder"
-  spec.version = "0.17.0"
+  spec.version = "0.18.0"
   spec.authors = ["Bouke van der Bijl"]
   spec.email = ["bouke@cheddar.me"]
   spec.homepage = "https://github.com/cheddar-me/pbbuilder"

--- a/test/pbbuilder_test.rb
+++ b/test/pbbuilder_test.rb
@@ -30,6 +30,23 @@ class PbbuilderTest < ActiveSupport::TestCase
     assert_equal "Eggs", person.favourite_foods["Breakfast"]
   end
 
+  test "allows assignment of prefab nested proto messages" do
+    max_proto = API::Person.new(name: "Max Verstappen")
+    james_proto = API::Person.new(name: "James Hunt")
+    friend_protos = [max_proto, james_proto]
+
+    person = Pbbuilder.new(API::Person.new) do |pb|
+      pb.name "Niki Lauda"
+      pb.friends friend_protos
+      pb.best_friend james_proto
+    end.target!
+
+    assert_equal "Niki Lauda", person.name
+    assert_equal "Max Verstappen", person.friends[0].name
+    assert_equal "James Hunt", person.friends[1].name
+    assert_equal "James Hunt", person.best_friend.name
+  end
+
   test "replaces the repeated field's value with the last one set" do
     person = Pbbuilder.new(API::Person.new) do |pb|
       pb.field_mask do


### PR DESCRIPTION
Some repeated protobufs in our app are used very frequently, with no changes. It makes sense to just store a proto message in memory and then assign it as needed throughout the various renders. But for that, pbbuilder needs to accept that message in the first place.